### PR TITLE
pylintrc: disable cyclic-import check

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -13,7 +13,6 @@
 #disable=no-absolute-import,bad-continuation,C0103,C0114,C0115,E1101,W0201,no-name-in-module
 disable=all
 enable=
-        cyclic-import,
         import-error,
         import-self,
         misplaced-future,


### PR DESCRIPTION
We have cyclic imports in Portage; pylint before 2.14.0 fails to find them.

Signed-off-by: Mike Gilbert <floppym@gentoo.org>